### PR TITLE
Changing to incbin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.riscv
 *.o
+*.bin

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,18 @@ RISCV_OBJCOPY ?= $(CROSS_COMPILE)objcopy
 
 .PHONY: clean
 
-RISCV_CFLAGS ?= -march=rv64im -mabi=lp64 -mcmodel=medany -static -nostdlib -nostartfiles
-bootrom.riscv: cce_ucode.o
-	$(RISCV_GCC) $(RISCV_CFLAGS) bootrom.S $^ -I$(@D) -o $@ -Tlink.ld -static -Wl,--no-gc-sections
+RISCV_CFLAGS ?= -march=rv64imafd -mabi=lp64 -mcmodel=medany -static -nostdlib -nostartfiles
+bootrom.riscv: bootrom.S cce_ucode.bin
+	$(RISCV_GCC) -o $@ $(RISCV_CFLAGS) $< -I$(@D) -Tlink.ld -static -Wl,--no-gc-sections
 
 # Currently only one bootrom is generated at a time
 COH_PROTO ?= mesi
-cce_ucode.o:
-	$(RISCV_OBJCOPY) -I binary -O elf64-littleriscv -B riscv $(BP_SDK_UCODE_DIR)/$(COH_PROTO).bin $@ --strip-all --add-symbol cce_ucode_bin=.data:0
+
+cce_ucode.bin: $(BP_SDK_UCODE_DIR)/$(COH_PROTO).bin
+	$(RISCV_OBJCOPY) -I binary -O binary --reverse-bytes=8 $< $@
 
 clean:
 	@rm -f bootrom.riscv
+	@rm -f cce_ucode.bin
+	@rm -f cce_ucode.mem
 

--- a/bootrom.S
+++ b/bootrom.S
@@ -14,8 +14,6 @@
 
 #define CFG_CORE_OFFSET 24
 
-.extern cce_ucode_bin
-
 .section .text.start
 .globl _start
 _start:
@@ -70,7 +68,7 @@ load_ucode:
     beq t3, t2, load_config
     sd t3, 0(t1)
     addi t0, t0, 8
-    addi t1, t1, 1
+    addi t1, t1, 8
     j load_ucode
         
     // Load the configuration data for the core. This switches the cache modes
@@ -116,4 +114,7 @@ load_config:
 // Should not get here
 halt:
     j halt
+
+cce_ucode_bin:
+.incbin "cce_ucode.bin"
 

--- a/link.ld
+++ b/link.ld
@@ -1,6 +1,5 @@
 SECTIONS
 {
-    . = 0x0000;
+    . = 0x00000;
     .text.start    : ALIGN(8) { *(.text.start)    }
-    .data          : ALIGN(8) { *(.data)          }
 }


### PR DESCRIPTION
This PR switches from a .o link to a .incbin strategy, which works better for relocated code with absolute addresses