### PR TITLE
parameterize march and mabi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 
+WITH_MARCH ?= rv64gc
+WITH_MABI ?= lp64d
+
 RISCV_GCC ?= $(CROSS_COMPILE)gcc
 RISCV_OBJCOPY ?= $(CROSS_COMPILE)objcopy
 
 .PHONY: clean
 
-RISCV_CFLAGS ?= -march=rv64gc -mabi=lp64d -mcmodel=medany -static -nostdlib -nostartfiles
+RISCV_CFLAGS ?= -march=$(WITH_MARCH) -mabi=$(WITH_MABI) -mcmodel=medany -static -nostdlib -nostartfiles
 bootrom.riscv: bootrom.S cce_ucode.bin
 	$(RISCV_GCC) -o $@ $(RISCV_CFLAGS) $< -I$(@D) -Tlink.ld -static -Wl,--no-gc-sections
 


### PR DESCRIPTION
Add Makefile flags to allow -march and -mabi option override when compiling the bootrom image.

BP supports the "C" extension through a parameter and therefore the toolchain should also support a way to compile programs with or without the extension. This change allows the user to specify whether their machine target uses "C" or not.