### PR TITLE
Fix for 32b loading of ucode

### DIFF
--- a/bootrom.S
+++ b/bootrom.S
@@ -64,8 +64,8 @@ _start:
     or t1, t1, t6
     li t2, CCE_INSTR_END
 load_ucode:
-    lw t3, 0(t0)
-    lw t4, 4(t0)
+    lwu t3, 0(t0)
+    lwu t4, 4(t0)
     slli t5, t4, 32
     or t5, t5, t3
     sd t5, 0(t1)


### PR DESCRIPTION
Very tricky bug.

Signed load word of 32b combined with shift-or led to some spurious bits being set on the end of ucode. For many instructions, these are nop bits, but for some e.g. branch instructions, this causes things to go off the rail